### PR TITLE
refactor(infra): Store connection strings in Azure Key Vault

### DIFF
--- a/AspireAppTest.AppHost/infra/apiservice.tmpl.yaml
+++ b/AspireAppTest.AppHost/infra/apiservice.tmpl.yaml
@@ -21,10 +21,12 @@ properties:
       - server: {{ .Env.AZURE_CONTAINER_REGISTRY_ENDPOINT }}
         identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}
     secrets:
-      - name: connectionstrings--lmsdb
-        value: '{{ .Env.POSTGRES_CONNECTIONSTRING }};Database=LMSdb'
-      - name: connectionstrings--cache
-        value: '{{ .Env.CACHE_CONNECTIONSTRING }}'
+      - name: sql-connection
+        keyVaultUrl: '{{ .Env.KEYVAULT_URI }}secrets/LMSdb-Conn'
+        identity: '{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}'
+      - name: cache-connection
+        keyVaultUrl: '{{ .Env.KEYVAULT_URI }}secrets/Cache-Conn'
+        identity: '{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}'
   template:
     containers:
       - image: {{ .Image }}
@@ -43,9 +45,9 @@ properties:
           - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY
             value: in_memory
           - name: ConnectionStrings__LMSdb
-            secretRef: connectionstrings--lmsdb
+            secretRef: sql-connection
           - name: ConnectionStrings__cache
-            secretRef: connectionstrings--cache
+            secretRef: cache-connection
     scale:
       minReplicas: 1
 tags:

--- a/AspireAppTest.AppHost/infra/keyvault/keyvault-secrets.module.bicep
+++ b/AspireAppTest.AppHost/infra/keyvault/keyvault-secrets.module.bicep
@@ -1,0 +1,28 @@
+targetScope = 'resourceGroup'
+
+@description('The name of the Key Vault (must already exist in this RG)')
+param vaultName string
+
+@description('Connection string for Postgres')
+@secure()
+param postgresConn string
+
+@description('Connection string for Redis')
+@secure()
+param cacheConn string
+
+// Write Postgres secret
+resource postgresSecret 'Microsoft.KeyVault/vaults/secrets@2021-06-01-preview' = {
+  name: '${vaultName}/LMSdb-Conn'
+  properties: {
+    value: postgresConn
+  }
+}
+
+// Write Redis secret
+resource cacheSecret 'Microsoft.KeyVault/vaults/secrets@2021-06-01-preview' = {
+  name: '${vaultName}/Cache-Conn'
+  properties: {
+    value: cacheConn
+  }
+}

--- a/AspireAppTest.AppHost/infra/keyvault/keyvault.module.bicep
+++ b/AspireAppTest.AppHost/infra/keyvault/keyvault.module.bicep
@@ -1,0 +1,41 @@
+@description('Name of the Key Vault')
+param vaultName string
+
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+@description('Managed Identity principal ID to grant access')
+param principalId string
+
+resource kv 'Microsoft.KeyVault/vaults@2022-07-01' = {
+  name: vaultName
+  location: location
+  properties: {
+    tenantId: subscription().tenantId
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+  enabledForTemplateDeployment: true
+  enabledForDiskEncryption: false
+  accessPolicies: []
+  enableRbacAuthorization: true
+  }
+}
+
+var secretUserRole = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '4633458b-17de-408a-b874-0445c86b69e6'  // Key Vault Secrets User
+)
+
+resource kvRole 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(kv.id, principalId, secretUserRole)
+  scope: kv
+  properties: {
+    principalId: principalId
+    roleDefinitionId: secretUserRole
+  }
+}
+
+output keyVaultUri string = kv.properties.vaultUri
+output keyVaultName string = kv.name

--- a/AspireAppTest.AppHost/infra/main.bicep
+++ b/AspireAppTest.AppHost/infra/main.bicep
@@ -54,6 +54,7 @@ module cache_roles 'cache-roles/cache-roles.module.bicep' = {
     principalName: resources.outputs.MANAGED_IDENTITY_NAME
   }
 }
+
 module postgres 'postgres/postgres.module.bicep' = {
   name: 'postgres'
   scope: rg
@@ -74,6 +75,26 @@ module postgres_roles 'postgres-roles/postgres-roles.module.bicep' = {
     principalType: 'ServicePrincipal'
   }
 }
+
+module keyvault 'keyvault/keyvault.module.bicep' = {
+  name: 'keyvault'
+  scope: rg
+  params: {
+    vaultName: '${environmentName}-kv'
+    principalId: resources.outputs.MANAGED_IDENTITY_PRINCIPAL_ID
+    location: location
+  }
+}
+module keyvaultSecrets 'keyvault/keyvault-secrets.module.bicep' = {
+  name: 'keyvault-secrets'
+  scope: rg
+  params: {
+    vaultName: keyvault.outputs.keyVaultName
+    postgresConn: postgres.outputs.connectionString
+    cacheConn: cache.outputs.connectionString
+  }
+}
+
 output MANAGED_IDENTITY_CLIENT_ID string = resources.outputs.MANAGED_IDENTITY_CLIENT_ID
 output MANAGED_IDENTITY_NAME string = resources.outputs.MANAGED_IDENTITY_NAME
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = resources.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_NAME
@@ -84,3 +105,5 @@ output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.AZURE_CONT
 output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
 output CACHE_CONNECTIONSTRING string = cache.outputs.connectionString
 output POSTGRES_CONNECTIONSTRING string = postgres.outputs.connectionString
+output KEYVAULT_URI string = keyvault.outputs.keyVaultUri
+output KEYVAULT_NAME string = keyvault.outputs.keyVaultName

--- a/AspireAppTest.AppHost/infra/webfrontend.tmpl.yaml
+++ b/AspireAppTest.AppHost/infra/webfrontend.tmpl.yaml
@@ -21,8 +21,9 @@ properties:
       - server: {{ .Env.AZURE_CONTAINER_REGISTRY_ENDPOINT }}
         identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}
     secrets:
-      - name: connectionstrings--cache
-        value: '{{ .Env.CACHE_CONNECTIONSTRING }}'
+      - name: cache-connection
+        keyVaultUrl: '{{ .Env.KEYVAULT_URI }}secrets/Cache-Conn'
+        identity: '{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}'
   template:
     containers:
       - image: {{ .Image }}
@@ -45,7 +46,7 @@ properties:
           - name: services__apiservice__https__0
             value: https://apiservice.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}
           - name: ConnectionStrings__cache
-            secretRef: connectionstrings--cache
+            secretRef: cache-connection
     scale:
       minReplicas: 1
 tags:


### PR DESCRIPTION
This commit refactors how connection strings are managed by introducing Azure Key Vault. Secrets are no longer passed directly as environment variables to the container apps.

- Adds new Bicep modules to provision a Key Vault and store the Postgres and Redis connection strings as secrets.
- Grants the container apps' managed identity the "Key Vault Secrets User" role to securely access the secrets.
- Updates the `apiservice` and `webfrontend` container app templates to reference the secrets directly from Key Vault.

This change improves security by centralizing secret management and removing sensitive data from environment configurations.